### PR TITLE
Fixed encoding of chain Ids, when the top byte is zero

### DIFF
--- a/besu/src/main/java/org/web3j/protocol/besu/crypto/crosschain/CrosschainTransactionEncoder.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/crypto/crosschain/CrosschainTransactionEncoder.java
@@ -24,6 +24,7 @@ package org.web3j.protocol.besu.crypto.crosschain;
  * specific language governing permissions and limitations under the License.
  */
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -38,6 +39,7 @@ import org.web3j.utils.Bytes;
 import org.web3j.utils.Numeric;
 
 import static org.web3j.crypto.TransactionEncoder.createEip155SignatureData;
+import static org.web3j.crypto.TransactionEncoder.toExactBytes;
 
 public class CrosschainTransactionEncoder {
 
@@ -53,11 +55,17 @@ public class CrosschainTransactionEncoder {
 
     private static byte[] encode(CrosschainRawTransaction rawTransaction, long chainId) {
         Sign.SignatureData signatureData =
-                new Sign.SignatureData((byte) chainId, new byte[] {}, new byte[] {});
+                new Sign.SignatureData(longToBytes(chainId), new byte[] {}, new byte[] {});
         // TODO Putting in the following line
-        //                    new Sign.SignatureData(longToBytes(chainId), new byte[] {}, new byte[]
+        //                            new Sign.SignatureData(longToBytes(chainId), new byte[] {},
+        // new byte[]
         // {});
         return encode(rawTransaction, signatureData);
+    }
+
+    private static byte[] longToBytes(final long chainId) {
+        BigInteger chainIdLong = BigInteger.valueOf(chainId);
+        return toExactBytes(chainIdLong);
     }
 
     private static byte[] encode(

--- a/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
+++ b/crypto/src/main/java/org/web3j/crypto/TransactionEncoder.java
@@ -63,8 +63,25 @@ public class TransactionEncoder {
         v = v.subtract(BigInteger.valueOf(LOWER_REAL_V));
         v = v.add(BigInteger.valueOf(chainId * 2));
         v = v.add(BigInteger.valueOf(CHAIN_ID_INC));
+        return new Sign.SignatureData(toExactBytes(v), signatureData.getR(), signatureData.getS());
+    }
 
-        return new Sign.SignatureData(v.toByteArray(), signatureData.getR(), signatureData.getS());
+    /**
+     * When RLP Encoding, ensure the top byte is not zero. BigInteger's toByteArray assumes the
+     * BigInteger is a signed value. With RLP encoding all values are unsigned. As such, for RLP
+     * encoding, having a top byte of zero doesn't make sense and is a bug.
+     *
+     * @param bigInteger Value to convert to a byte array.
+     * @return Byte array equivalent of the unsigned bigInteger value.
+     */
+    public static byte[] toExactBytes(BigInteger bigInteger) {
+        byte[] bytes = bigInteger.toByteArray();
+        if (bytes[0] == 0) {
+            byte[] temp = new byte[bytes.length - 1];
+            System.arraycopy(bytes, 1, temp, 0, temp.length);
+            bytes = temp;
+        }
+        return bytes;
     }
 
     @Deprecated


### PR DESCRIPTION
Signed-off-by: Peter  Robinson <drinkcoffee@eml.cc>

Ensures the chain ID is encoded correctly. Values such as 0x81 should be encoded as one byte rather than two, as RLP encoding only deals with positive values. As such, there is no need for a zero byte.