### PR TITLE
Add new API method for key generation. 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,98 @@
+---
+version: 2.1
+executors:
+  web3j_executor_med: # 2cpu, 4G ram
+    docker:
+      - image: circleci/openjdk:8-jdk-stretch
+    resource_class: medium
+    working_directory: ~/project
+    environment:
+      GRADLE_OPTS: -Xmx2048m -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=2
+
+  web3j_executor_xl: # 8cpu, 16G ram
+    docker:
+      - image: circleci/openjdk:8-jdk-stretch
+    resource_class: xlarge
+    working_directory: ~/project
+    environment:
+      GRADLE_OPTS: -Xmx4096m -Dorg.gradle.daemon=false -Dorg.gradle.parallel=true -Dorg.gradle.workers.max=4
+      
+commands:
+  prepare:
+    description: "Prepare"
+    steps:
+      - checkout
+      - restore_cache:
+          name: Restore cached gradle dependencies
+          keys:
+            - deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
+            - deps-{{ checksum "build.gradle" }}
+            - deps-
+
+  capture_test_results:
+    description: "Capture test results"
+    steps:
+      - run:
+          name: Gather test results
+          when: always
+          command: |
+            FILES=`find . -name test-results`
+            for FILE in $FILES
+            do
+              MODULE=`echo "$FILE" | sed -e 's@./\(.*\)/build/test-results@\1@'`
+              TARGET="build/test-results/$MODULE"
+              mkdir -p "$TARGET"
+              cp -rf ${FILE}/*/* "$TARGET"
+            done
+      - store_test_results:
+          path: build/test-results
+
+jobs:
+  assemble:
+    executor: web3j_executor_xl
+    steps:
+      - prepare
+      - run:
+          name: Assemble
+          command: |
+            ./gradlew --no-daemon --parallel clean spotlessCheck compileJava compileTestJava assemble
+      - save_cache:
+          name: Caching gradle dependencies
+          key: deps-{{ checksum "build.gradle" }}-{{ .Branch }}-{{ .Revision }}
+          paths:
+            - .gradle
+            - ~/.gradle
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - ./
+      - store_artifacts:
+          name: Distribution artifacts
+          path:  build/distributions
+          destination: distributions
+          when: always
+
+  unitTests:
+    executor: web3j_executor_xl
+    steps:
+      - prepare
+      - attach_workspace:
+          at: ~/project
+      - run:
+          name: Build
+          no_output_timeout: 20m
+          command: |
+            ./gradlew --no-daemon --parallel build
+      - capture_test_results
+
+
+workflows:
+  version: 2
+  default:
+    jobs:
+      - assemble
+      - unitTests:
+          requires:
+            - assemble
+
+

--- a/besu/src/main/java/org/web3j/protocol/besu/Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/Besu.java
@@ -21,11 +21,16 @@ import org.web3j.protocol.admin.methods.response.BooleanResponse;
 import org.web3j.protocol.besu.crypto.crosschain.BlsThresholdCryptoSystem;
 import org.web3j.protocol.besu.response.BesuEthAccountsMapResponse;
 import org.web3j.protocol.besu.response.BesuFullDebugTraceResponse;
-import org.web3j.protocol.besu.response.crosschain.CrossListMultichainNodesResponse;
-import org.web3j.protocol.besu.response.crosschain.CrosschainCheckUnlock;
-import org.web3j.protocol.besu.response.crosschain.CrosschainIsLockable;
-import org.web3j.protocol.besu.response.crosschain.CrosschainIsLocked;
-import org.web3j.protocol.besu.response.crosschain.CrosschainProcessSubordinateView;
+import org.web3j.protocol.besu.response.crosschain.CrossBlockchainPublicKeyResponse;
+import org.web3j.protocol.besu.response.crosschain.CrossCheckUnlockResponse;
+import org.web3j.protocol.besu.response.crosschain.CrossIsLockableResponse;
+import org.web3j.protocol.besu.response.crosschain.CrossIsLockedResponse;
+import org.web3j.protocol.besu.response.crosschain.CrossProcessSubordinateViewResponse;
+import org.web3j.protocol.besu.response.crosschain.KeyGenFailureReasonResponse;
+import org.web3j.protocol.besu.response.crosschain.KeyGenNodesDroppedOutOfKeyGenerationResponse;
+import org.web3j.protocol.besu.response.crosschain.KeyStatusResponse;
+import org.web3j.protocol.besu.response.crosschain.ListCoordinationContractsResponse;
+import org.web3j.protocol.besu.response.crosschain.ListNodesResponse;
 import org.web3j.protocol.besu.response.crosschain.LongResponse;
 import org.web3j.protocol.besu.response.crosschain.NoResponse;
 import org.web3j.protocol.besu.response.privacy.PrivCreatePrivacyGroup;
@@ -99,27 +104,53 @@ public interface Besu extends Eea {
 
     Request<?, PrivGetTransactionReceipt> privGetTransactionReceipt(final String transactionHash);
 
-    Request<?, EthSendTransaction> crosschainSendCrossChainRawTransaction(
-            String signedTransactionData);
+    Request<?, NoResponse> crossActivateKey(final long keyVersion);
 
-    Request<?, CrosschainProcessSubordinateView> crosschainProcessSubordinateView(
-            String signedTransactionData);
-
-    Request<?, CrosschainIsLockable> crosschainIsLockable(
-            String address, DefaultBlockParameter defaultBlockParameter);
-
-    Request<?, CrosschainIsLocked> crosschainIsLocked(
-            String address, DefaultBlockParameter defaultBlockParameter);
-
-    Request<?, CrosschainCheckUnlock> crosschainCheckUnlock(String address);
-
-    public Request<?, NoResponse> crossAddMultichainNode(
+    Request<?, NoResponse> crossAddMultichainNode(
             final BigInteger blockchainId, final String ipAddressAndPort);
 
-    public Request<?, CrossListMultichainNodesResponse> crossListMultichainNodes();
+    Request<?, NoResponse> crossAddCoordinationContract(
+            final String address, final String ipAddressAndPort);
 
-    public Request<?, NoResponse> crossRemoveMultichainNode(final BigInteger blockchainId);
+    Request<?, CrossCheckUnlockResponse> crossCheckUnlock(String address);
 
-    public Request<?, LongResponse> crossStartThresholdKeyGeneration(
+    Request<?, LongResponse> crossGetActiveKeyVersion();
+
+    Request<?, CrossBlockchainPublicKeyResponse> crossGetBlockchainPublicKey();
+
+    Request<?, CrossBlockchainPublicKeyResponse> crossGetBlockchainPublicKey(final long keyVersion);
+
+    Request<?, ListNodesResponse> crossGetKeyActiveNodes(final long keyVersion);
+
+    Request<?, KeyGenFailureReasonResponse> crossGetKeyGenFailureReason(final long keyVersion);
+
+    Request<?, KeyGenNodesDroppedOutOfKeyGenerationResponse>
+            crossGetKeyGenNodesDroppedOutOfKeyGeneration(final long keyVersion);
+
+    Request<?, KeyStatusResponse> crossGetKeyStatus(final long keyVersion);
+
+    Request<?, CrossIsLockableResponse> crossIsLockable(
+            String address, DefaultBlockParameter defaultBlockParameter);
+
+    Request<?, CrossIsLockedResponse> crossIsLocked(
+            String address, DefaultBlockParameter defaultBlockParameter);
+
+    Request<?, ListCoordinationContractsResponse> crossListCoordinationContracts();
+
+    Request<?, ListNodesResponse> crossListMultichainNodes();
+
+    Request<?, CrossProcessSubordinateViewResponse> crossProcessSubordinateView(
+            String signedTransactionData);
+
+    Request<?, NoResponse> crossRemoveCoordinationContract(
+            final BigInteger blockchainId, final String address);
+
+    Request<?, NoResponse> crossRemoveMultichainNode(final BigInteger blockchainId);
+
+    Request<?, EthSendTransaction> crossSendCrossChainRawTransaction(String signedTransactionData);
+
+    Request<?, NoResponse> crossSetKeyGenerationContractAddress(final String address);
+
+    Request<?, LongResponse> crossStartThresholdKeyGeneration(
             final int threshold, final BlsThresholdCryptoSystem cryptoSystem);
 }

--- a/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/JsonRpc2_0Besu.java
@@ -24,11 +24,16 @@ import org.web3j.protocol.besu.crypto.crosschain.BlsThresholdCryptoSystem;
 import org.web3j.protocol.besu.request.CreatePrivacyGroupRequest;
 import org.web3j.protocol.besu.response.BesuEthAccountsMapResponse;
 import org.web3j.protocol.besu.response.BesuFullDebugTraceResponse;
-import org.web3j.protocol.besu.response.crosschain.CrossListMultichainNodesResponse;
-import org.web3j.protocol.besu.response.crosschain.CrosschainCheckUnlock;
-import org.web3j.protocol.besu.response.crosschain.CrosschainIsLockable;
-import org.web3j.protocol.besu.response.crosschain.CrosschainIsLocked;
-import org.web3j.protocol.besu.response.crosschain.CrosschainProcessSubordinateView;
+import org.web3j.protocol.besu.response.crosschain.CrossBlockchainPublicKeyResponse;
+import org.web3j.protocol.besu.response.crosschain.CrossCheckUnlockResponse;
+import org.web3j.protocol.besu.response.crosschain.CrossIsLockableResponse;
+import org.web3j.protocol.besu.response.crosschain.CrossIsLockedResponse;
+import org.web3j.protocol.besu.response.crosschain.CrossProcessSubordinateViewResponse;
+import org.web3j.protocol.besu.response.crosschain.KeyGenFailureReasonResponse;
+import org.web3j.protocol.besu.response.crosschain.KeyGenNodesDroppedOutOfKeyGenerationResponse;
+import org.web3j.protocol.besu.response.crosschain.KeyStatusResponse;
+import org.web3j.protocol.besu.response.crosschain.ListCoordinationContractsResponse;
+import org.web3j.protocol.besu.response.crosschain.ListNodesResponse;
 import org.web3j.protocol.besu.response.crosschain.LongResponse;
 import org.web3j.protocol.besu.response.crosschain.NoResponse;
 import org.web3j.protocol.besu.response.privacy.PrivCreatePrivacyGroup;
@@ -193,48 +198,9 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
                 PrivGetTransactionReceipt.class);
     }
 
-    public Request<?, EthSendTransaction> crosschainSendCrossChainRawTransaction(
-            String signedTransactionData) {
+    public Request<?, NoResponse> crossActivateKey(final long keyVersion) {
         return new Request<>(
-                "cross_sendRawCrosschainTransaction",
-                Arrays.asList(signedTransactionData),
-                web3jService,
-                EthSendTransaction.class);
-    }
-
-    public Request<?, CrosschainProcessSubordinateView> crosschainProcessSubordinateView(
-            String signedTransactionData) {
-        return new Request<>(
-                "cross_processSubordinateView",
-                Arrays.asList(signedTransactionData),
-                web3jService,
-                CrosschainProcessSubordinateView.class);
-    }
-
-    public Request<?, CrosschainIsLockable> crosschainIsLockable(
-            String address, DefaultBlockParameter defaultBlockParameter) {
-        return new Request<>(
-                "cross_isLockable",
-                Arrays.asList(address, defaultBlockParameter.getValue()),
-                web3jService,
-                CrosschainIsLockable.class);
-    }
-
-    public Request<?, CrosschainIsLocked> crosschainIsLocked(
-            String address, DefaultBlockParameter defaultBlockParameter) {
-        return new Request<>(
-                "cross_isLocked",
-                Arrays.asList(address, defaultBlockParameter.getValue()),
-                web3jService,
-                CrosschainIsLocked.class);
-    }
-
-    public Request<?, CrosschainCheckUnlock> crosschainCheckUnlock(String address) {
-        return new Request<>(
-                "cross_checkUnlock",
-                Arrays.asList(address),
-                web3jService,
-                CrosschainCheckUnlock.class);
+                "cross_activateKey", Arrays.asList(keyVersion), web3jService, NoResponse.class);
     }
 
     public Request<?, NoResponse> crossAddMultichainNode(
@@ -246,18 +212,155 @@ public class JsonRpc2_0Besu extends JsonRpc2_0Eea implements Besu {
                 NoResponse.class);
     }
 
-    public Request<?, CrossListMultichainNodesResponse> crossListMultichainNodes() {
+    public Request<?, NoResponse> crossAddCoordinationContract(
+            final String address, final String ipAddressAndPort) {
+        return new Request<>(
+                "cross_addCoordinationContract",
+                Arrays.asList(address, ipAddressAndPort),
+                web3jService,
+                NoResponse.class);
+    }
+
+    public Request<?, CrossCheckUnlockResponse> crossCheckUnlock(final String address) {
+        return new Request<>(
+                "cross_checkUnlock",
+                Arrays.asList(address),
+                web3jService,
+                CrossCheckUnlockResponse.class);
+    }
+
+    public Request<?, LongResponse> crossGetActiveKeyVersion() {
+        return new Request<>(
+                "cross_getActiveKeyVersion",
+                Collections.<String>emptyList(),
+                web3jService,
+                LongResponse.class);
+    }
+
+    public Request<?, CrossBlockchainPublicKeyResponse> crossGetBlockchainPublicKey() {
+        return new Request<>(
+                "cross_getBlockchainPublicKey",
+                Collections.<String>emptyList(),
+                web3jService,
+                CrossBlockchainPublicKeyResponse.class);
+    }
+
+    public Request<?, CrossBlockchainPublicKeyResponse> crossGetBlockchainPublicKey(
+            final long keyVersion) {
+        return new Request<>(
+                "cross_getBlockchainPublicKey",
+                Arrays.asList(keyVersion),
+                web3jService,
+                CrossBlockchainPublicKeyResponse.class);
+    }
+
+    public Request<?, ListNodesResponse> crossGetKeyActiveNodes(final long keyVersion) {
+        return new Request<>(
+                "cross_getKeyActiveNodes",
+                Arrays.asList(keyVersion),
+                web3jService,
+                ListNodesResponse.class);
+    }
+
+    public Request<?, KeyGenFailureReasonResponse> crossGetKeyGenFailureReason(
+            final long keyVersion) {
+        return new Request<>(
+                "cross_getKeyGenFailureReason",
+                Arrays.asList(keyVersion),
+                web3jService,
+                KeyGenFailureReasonResponse.class);
+    }
+
+    public Request<?, KeyGenNodesDroppedOutOfKeyGenerationResponse>
+            crossGetKeyGenNodesDroppedOutOfKeyGeneration(final long keyVersion) {
+        return new Request<>(
+                "cross_getKeyGenNodesDroppedOutOfKeyGeneration",
+                Arrays.asList(keyVersion),
+                web3jService,
+                KeyGenNodesDroppedOutOfKeyGenerationResponse.class);
+    }
+
+    public Request<?, KeyStatusResponse> crossGetKeyStatus(final long keyVersion) {
+        return new Request<>(
+                "cross_getKeyStatus",
+                Arrays.asList(keyVersion),
+                web3jService,
+                KeyStatusResponse.class);
+    }
+
+    public Request<?, CrossIsLockableResponse> crossIsLockable(
+            String address, DefaultBlockParameter defaultBlockParameter) {
+        return new Request<>(
+                "cross_isLockable",
+                Arrays.asList(address, defaultBlockParameter.getValue()),
+                web3jService,
+                CrossIsLockableResponse.class);
+    }
+
+    public Request<?, CrossIsLockedResponse> crossIsLocked(
+            String address, DefaultBlockParameter defaultBlockParameter) {
+        return new Request<>(
+                "cross_isLocked",
+                Arrays.asList(address, defaultBlockParameter.getValue()),
+                web3jService,
+                CrossIsLockedResponse.class);
+    }
+
+    public Request<?, ListCoordinationContractsResponse> crossListCoordinationContracts() {
+        return new Request<>(
+                "cross_listCoordinationContracts",
+                Collections.<String>emptyList(),
+                web3jService,
+                ListCoordinationContractsResponse.class);
+    }
+
+    public Request<?, ListNodesResponse> crossListMultichainNodes() {
         return new Request<>(
                 "cross_listMultichainNodes",
                 Collections.<String>emptyList(),
                 web3jService,
-                CrossListMultichainNodesResponse.class);
+                ListNodesResponse.class);
+    }
+
+    public Request<?, CrossProcessSubordinateViewResponse> crossProcessSubordinateView(
+            String signedTransactionData) {
+        return new Request<>(
+                "cross_processSubordinateView",
+                Arrays.asList(signedTransactionData),
+                web3jService,
+                CrossProcessSubordinateViewResponse.class);
+    }
+
+    public Request<?, NoResponse> crossRemoveCoordinationContract(
+            final BigInteger blockchainId, final String address) {
+        return new Request<>(
+                "cross_removeCoordinationContract",
+                Arrays.asList(blockchainId, address),
+                web3jService,
+                NoResponse.class);
     }
 
     public Request<?, NoResponse> crossRemoveMultichainNode(final BigInteger blockchainId) {
         return new Request<>(
                 "cross_removeMultichainNode",
                 Arrays.asList(blockchainId),
+                web3jService,
+                NoResponse.class);
+    }
+
+    public Request<?, EthSendTransaction> crossSendCrossChainRawTransaction(
+            String signedTransactionData) {
+        return new Request<>(
+                "cross_sendRawCrosschainTransaction",
+                Arrays.asList(signedTransactionData),
+                web3jService,
+                EthSendTransaction.class);
+    }
+
+    public Request<?, NoResponse> crossSetKeyGenerationContractAddress(final String address) {
+        return new Request<>(
+                "cross_setKeyGenerationContractAddress",
+                Arrays.asList(address),
                 web3jService,
                 NoResponse.class);
     }

--- a/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/CoordinationContractInformation.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/CoordinationContractInformation.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.besu.response.crosschain;
+
+import java.math.BigInteger;
+
+public class CoordinationContractInformation {
+    public BigInteger coordinationBlockchainId;
+    public String coodinationContract;
+    public String ipAddressAndPort;
+
+    CoordinationContractInformation(
+            final BigInteger coordinationBlockchainId,
+            final String coodinationContract,
+            final String ipAddressAndPort) {
+        this.coodinationContract = coodinationContract;
+        this.coordinationBlockchainId = coordinationBlockchainId;
+        this.ipAddressAndPort = ipAddressAndPort;
+    }
+}

--- a/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/CrossBlockchainPublicKeyResponse.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/CrossBlockchainPublicKeyResponse.java
@@ -26,9 +26,9 @@ package org.web3j.protocol.besu.response.crosschain;
 
 import org.web3j.protocol.core.Response;
 
-public class CrosschainCheckUnlock extends Response<String> {
+public class CrossBlockchainPublicKeyResponse extends Response<String> {
 
-    public String getValue() {
+    public String getKey() {
         return getResult();
     }
 }

--- a/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/CrossCheckUnlockResponse.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/CrossCheckUnlockResponse.java
@@ -11,15 +11,24 @@
  * specific language governing permissions and limitations under the License.
  */
 package org.web3j.protocol.besu.response.crosschain;
-
-import java.math.BigInteger;
-import java.util.List;
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
 
 import org.web3j.protocol.core.Response;
 
-public class CrossListMultichainNodesResponse extends Response<List<BigInteger>> {
+public class CrossCheckUnlockResponse extends Response<String> {
 
-    public List<BigInteger> getNodes() {
+    public String getValue() {
         return getResult();
     }
 }

--- a/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/CrossIsLockableResponse.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/CrossIsLockableResponse.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.besu.response.crosschain;
+/*
+ * Copyright 2019 ConsenSys AG.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+
+import java.math.BigInteger;
+
+import org.web3j.protocol.core.Response;
+import org.web3j.utils.Numeric;
+
+public class CrossIsLockableResponse extends Response<String> {
+
+    public Boolean isLockable() {
+        BigInteger value = Numeric.decodeQuantity(getResult());
+        return (value.equals(BigInteger.ONE));
+    }
+}

--- a/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/CrossIsLockedResponse.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/CrossIsLockedResponse.java
@@ -29,7 +29,7 @@ import java.math.BigInteger;
 import org.web3j.protocol.core.Response;
 import org.web3j.utils.Numeric;
 
-public class CrosschainIsLocked extends Response<String> {
+public class CrossIsLockedResponse extends Response<String> {
 
     public Boolean isLocked() {
         BigInteger value = Numeric.decodeQuantity(getResult());

--- a/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/CrossProcessSubordinateViewResponse.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/CrossProcessSubordinateViewResponse.java
@@ -24,15 +24,11 @@ package org.web3j.protocol.besu.response.crosschain;
  * specific language governing permissions and limitations under the License.
  */
 
-import java.math.BigInteger;
-
 import org.web3j.protocol.core.Response;
-import org.web3j.utils.Numeric;
 
-public class CrosschainIsLockable extends Response<String> {
+public class CrossProcessSubordinateViewResponse extends Response<String> {
 
-    public Boolean isLockable() {
-        BigInteger value = Numeric.decodeQuantity(getResult());
-        return (value.equals(BigInteger.ONE));
+    public String getValue() {
+        return getResult();
     }
 }

--- a/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/KeyGenFailureReasonResponse.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/KeyGenFailureReasonResponse.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.besu.response.crosschain;
+
+import org.web3j.protocol.core.Response;
+
+public class KeyGenFailureReasonResponse extends Response<Integer> {
+    public KeyGenFailureToCompleteReason getFailureReason() {
+        return KeyGenFailureToCompleteReason.create(getResult());
+    }
+}

--- a/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/KeyGenFailureToCompleteReason.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/KeyGenFailureToCompleteReason.java
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.besu.response.crosschain;
+
+public enum KeyGenFailureToCompleteReason {
+    UNKNOWN_KEY(Constants.UNKNOWN_KEY),
+    NO_FAILURE_THUS_FAR(Constants.NO_FAILURE_THUS_FAR),
+    DID_NOT_POST_XVALUE(Constants.DID_NOT_POST_XVALUE),
+    DID_NOT_POST_COMMITMENT(Constants.DID_NOT_POST_COMMITMENT),
+    DID_NOT_POST_COEFFICIENT_PUBLIC_VALUES(Constants.DID_NOT_POST_COEFFICIENT_PUBLIC_VALUES),
+    INVALID_COEFFICIENT_PUBLIC_VALUES(Constants.INVALID_COEFFICIENT_PUBLIC_VALUES),
+    COEFFICIENT_PUBLIC_VALUES_DID_NOT_MATCH_COMMITMENTS(
+            Constants.COEFFICIENT_PUBLIC_VALUES_DID_NOT_MATCH_COMMITMENTS),
+    DID_NOT_SEND_PRIVATE_VALUES(Constants.DID_NOT_SEND_PRIVATE_VALUES),
+    PRIVATE_VALUES_DID_NOT_MATCH_COEFFICIENT_PUBLIC_VALUES(
+            Constants.PRIVATE_VALUES_DID_NOT_MATCH_COEFFICIENT_PUBLIC_VALUES),
+    SUCCESS(Constants.SUCCESS);
+
+    private static class Constants {
+        private static final int UNKNOWN_KEY = 0;
+        private static final int NO_FAILURE_THUS_FAR = 1;
+        private static final int DID_NOT_POST_XVALUE = 2;
+        private static final int DID_NOT_POST_COMMITMENT = 3;
+        private static final int DID_NOT_POST_COEFFICIENT_PUBLIC_VALUES = 4;
+        private static final int INVALID_COEFFICIENT_PUBLIC_VALUES = 5;
+        private static final int COEFFICIENT_PUBLIC_VALUES_DID_NOT_MATCH_COMMITMENTS = 6;
+        private static final int DID_NOT_SEND_PRIVATE_VALUES = 7;
+        private static final int PRIVATE_VALUES_DID_NOT_MATCH_COEFFICIENT_PUBLIC_VALUES = 8;
+        private static final int SUCCESS = 20;
+    }
+
+    public int value;
+
+    KeyGenFailureToCompleteReason(final int val) {
+        this.value = val;
+    }
+
+    public static KeyGenFailureToCompleteReason create(final int val) {
+        switch (val) {
+            case Constants.UNKNOWN_KEY:
+                return UNKNOWN_KEY;
+            case Constants.NO_FAILURE_THUS_FAR:
+                return NO_FAILURE_THUS_FAR;
+            case Constants.DID_NOT_POST_XVALUE:
+                return DID_NOT_POST_XVALUE;
+            case Constants.DID_NOT_POST_COMMITMENT:
+                return DID_NOT_POST_COMMITMENT;
+            case Constants.DID_NOT_POST_COEFFICIENT_PUBLIC_VALUES:
+                return DID_NOT_POST_COEFFICIENT_PUBLIC_VALUES;
+            case Constants.INVALID_COEFFICIENT_PUBLIC_VALUES:
+                return INVALID_COEFFICIENT_PUBLIC_VALUES;
+            case Constants.COEFFICIENT_PUBLIC_VALUES_DID_NOT_MATCH_COMMITMENTS:
+                return COEFFICIENT_PUBLIC_VALUES_DID_NOT_MATCH_COMMITMENTS;
+            case Constants.DID_NOT_SEND_PRIVATE_VALUES:
+                return DID_NOT_SEND_PRIVATE_VALUES;
+            case Constants.PRIVATE_VALUES_DID_NOT_MATCH_COEFFICIENT_PUBLIC_VALUES:
+                return PRIVATE_VALUES_DID_NOT_MATCH_COEFFICIENT_PUBLIC_VALUES;
+            case Constants.SUCCESS:
+                return SUCCESS;
+
+            default:
+                String error = "Unknown KeyGenFailureToCompleteReason: " + val;
+                throw new RuntimeException(error);
+        }
+    }
+}

--- a/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/KeyGenNodesDroppedOutOfKeyGenerationResponse.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/KeyGenNodesDroppedOutOfKeyGenerationResponse.java
@@ -1,0 +1,21 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.besu.response.crosschain;
+
+import java.math.BigInteger;
+import java.util.Map;
+
+import org.web3j.protocol.core.Response;
+
+public class KeyGenNodesDroppedOutOfKeyGenerationResponse
+        extends Response<Map<BigInteger, KeyGenFailureToCompleteReason>> {}

--- a/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/KeyStatus.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/KeyStatus.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.besu.response.crosschain;
+
+public enum KeyStatus {
+    UNKNOWN_KEY(Constants.UNKNOWN_KEY),
+    KEY_GEN_POST_XVALUE(Constants.KEY_GEN_POST_XVALUE),
+    KEY_GEN_POST_COMMITMENT(Constants.KEY_GEN_POST_COMMITMENT),
+    KEY_GEN_PUBLIC_VALUES(Constants.KEY_GEN_PUBLIC_VALUES),
+    KEY_GEN_PRIVATE_VALUES(Constants.KEY_GEN_SEND_PRIVATE_VALUES),
+    KEY_GEN_COMPLETE(Constants.KEY_GEN_COMPLETE),
+    ACTIVE_KEY(Constants.ACTIVE_KEY);
+
+    private static class Constants {
+        private static final int UNKNOWN_KEY = 0;
+        private static final int KEY_GEN_POST_XVALUE = 1;
+        private static final int KEY_GEN_POST_COMMITMENT = 2;
+        private static final int KEY_GEN_PUBLIC_VALUES = 3;
+        private static final int KEY_GEN_SEND_PRIVATE_VALUES = 4;
+        private static final int KEY_GEN_COMPLETE = 5;
+        private static final int ACTIVE_KEY = 6;
+    }
+
+    public int value;
+
+    KeyStatus(final int val) {
+        this.value = val;
+    }
+
+    public static KeyStatus create(final int val) {
+        switch (val) {
+            case Constants.UNKNOWN_KEY:
+                return UNKNOWN_KEY;
+            case Constants.KEY_GEN_POST_XVALUE:
+                return KEY_GEN_POST_XVALUE;
+            case Constants.KEY_GEN_POST_COMMITMENT:
+                return KEY_GEN_POST_COMMITMENT;
+            case Constants.KEY_GEN_PUBLIC_VALUES:
+                return KEY_GEN_PUBLIC_VALUES;
+            case Constants.KEY_GEN_COMPLETE:
+                return KEY_GEN_COMPLETE;
+            case Constants.ACTIVE_KEY:
+                return ACTIVE_KEY;
+            case Constants.KEY_GEN_SEND_PRIVATE_VALUES:
+                return KEY_GEN_PRIVATE_VALUES;
+            default:
+                String error = "Unknown KeyStatus: " + val;
+                throw new RuntimeException(error);
+        }
+    }
+}

--- a/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/KeyStatusResponse.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/KeyStatusResponse.java
@@ -1,0 +1,17 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.besu.response.crosschain;
+
+import org.web3j.protocol.core.Response;
+
+public class KeyStatusResponse extends Response<KeyStatus> {}

--- a/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/ListCoordinationContractsResponse.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/ListCoordinationContractsResponse.java
@@ -11,24 +11,15 @@
  * specific language governing permissions and limitations under the License.
  */
 package org.web3j.protocol.besu.response.crosschain;
-/*
- * Copyright 2019 ConsenSys AG.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
- * the License. You may obtain a copy of the License at
- *
- * http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
- * specific language governing permissions and limitations under the License.
- */
+
+import java.math.BigInteger;
+import java.util.List;
 
 import org.web3j.protocol.core.Response;
 
-public class CrosschainProcessSubordinateView extends Response<String> {
+public class ListCoordinationContractsResponse extends Response<List<BigInteger>> {
 
-    public String getValue() {
+    public List<BigInteger> getNodes() {
         return getResult();
     }
 }

--- a/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/ListNodesResponse.java
+++ b/besu/src/main/java/org/web3j/protocol/besu/response/crosschain/ListNodesResponse.java
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2019 Web3 Labs LTD.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.web3j.protocol.besu.response.crosschain;
+
+import java.math.BigInteger;
+import java.util.List;
+
+import org.web3j.protocol.core.Response;
+
+public class ListNodesResponse extends Response<List<BigInteger>> {
+
+    public List<BigInteger> getNodes() {
+        return getResult();
+    }
+}

--- a/besu/src/main/java/org/web3j/tx/CrosschainTransactionManager.java
+++ b/besu/src/main/java/org/web3j/tx/CrosschainTransactionManager.java
@@ -39,7 +39,7 @@ import org.web3j.protocol.besu.Besu;
 import org.web3j.protocol.besu.crypto.crosschain.CrosschainRawTransaction;
 import org.web3j.protocol.besu.crypto.crosschain.CrosschainTransactionEncoder;
 import org.web3j.protocol.besu.crypto.crosschain.CrosschainTransactionType;
-import org.web3j.protocol.besu.response.crosschain.CrosschainProcessSubordinateView;
+import org.web3j.protocol.besu.response.crosschain.CrossProcessSubordinateViewResponse;
 import org.web3j.protocol.core.methods.response.EthSendTransaction;
 import org.web3j.protocol.core.methods.response.TransactionReceipt;
 import org.web3j.protocol.exceptions.TransactionException;
@@ -268,7 +268,7 @@ public class CrosschainTransactionManager extends RawTransactionManager {
             throws IOException, TransactionException {
         String hexValue = Numeric.toHexString(signedMessage);
         EthSendTransaction transactionResponse =
-                this.besu.crosschainSendCrossChainRawTransaction(hexValue).send();
+                this.besu.crossSendCrossChainRawTransaction(hexValue).send();
 
         if (transactionResponse != null && !transactionResponse.hasError()) {
             String txHashLocal = Hash.sha3(hexValue);
@@ -305,8 +305,8 @@ public class CrosschainTransactionManager extends RawTransactionManager {
                 createSignedSubordinateView(gasPrice, gasLimit, to, data, value, crosschainContext);
 
         String hexValue = Numeric.toHexString(signedMessage);
-        CrosschainProcessSubordinateView response =
-                this.besu.crosschainProcessSubordinateView(hexValue).send();
+        CrossProcessSubordinateViewResponse response =
+                this.besu.crossProcessSubordinateView(hexValue).send();
 
         String retrunValue = response.getValue();
         List<Type> values =


### PR DESCRIPTION
Renamed web3j functions to match RPC APIs. That is crosschain_ becomes cross_
New methods added to Web3J to match all cross RPC methods

Signed-off-by: Peter  Robinson <drinkcoffee@eml.cc>